### PR TITLE
Calculate Phoneme Error Rate Correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,39 @@ The dataset includes character pairs along with their corresponding ground truth
 
 ## Metrics
 
-The benchmark uses the following metrics:
+The benchmark evaluates Cantonese G2P systems using two primary metrics:
 
-- **Accuracy**: The percentage of words that are correctly converted the specified character from graphemes to phonemes.
-- **Phoneme Error Rate (PER)**: The percentage of phonemes that are incorrectly predicted.
+### Accuracy
+
+- **Definition**: The percentage of instances where the specified character within a word is correctly converted from graphemes to phonemes.
+- **Purpose**: This metric measures how often the G2P model accurately predicts the phoneme for the target character in the context of the word.
+
+### Phoneme Error Rate (PER)
+
+- **Definition**: The proportion of phoneme components that are incorrectly predicted.
+- **Calculation Details**:
+  - **Syllable Decomposition**: Each Jyutping syllable is broken down into four components: **onset**, **nucleus**, **coda**, and **tone**.
+  - **Hamming Distance**: PER is calculated by computing the Hamming distance between the predicted and ground truth quadruples (onset, nucleus, coda, tone).
+    - For example, if the ground truth is `(s, a, i, 2)` and the prediction is `(s, a, m, 2)`, the Hamming distance is 1 (since only the coda differs).
+  - **Multiple Labels Handling**: If multiple valid pronunciations (alternative labels) exist for a character, the PER is computed using the label that minimizes the Hamming distance to the prediction.
+- **Purpose**: PER provides a fine-grained evaluation by identifying specific phoneme components where errors occur, offering insights into the model's phonological performance.
+
+### Rationale for Metric Choices
+
+#### Exclusion of Levenshtein Distance
+
+Previously, the Levenshtein distance was considered for evaluating G2P performance but was found to be unsuitable for this benchmark due to:
+
+1. **Dependency on Romanization System**:
+   - The Levenshtein distance operates on the Jyutping romanization strings, which can bias the results based on spelling conventions rather than actual phonetic differences.
+   - Different romanization systems might represent the same sounds with different letters or letter combinations, affecting the distance calculation.
+
+2. **Positional Pronunciation Variations**:
+   - In Cantonese, certain letters represent sounds that change depending on their position within a syllable.
+     - **Example**: The letters **p**, **t**, and **k** are aspirated when they appear at the beginning (**onset**) of a syllable but are unreleased when they appear at the end (**coda**).
+   - Levenshtein distance does not account for these positional differences, potentially overestimating errors when letters are the same but their pronunciations differ due to their positions.
+
+By using **Accuracy** and **Phoneme Error Rate (PER)** based on phonetic components, the benchmark provides a more accurate and meaningful evaluation of G2P systems that reflects true phonological performance rather than orthographic or romanization discrepancies.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The dataset includes character pairs along with their corresponding ground truth
 The benchmark uses the following metrics:
 
 - **Accuracy**: The percentage of words that are correctly converted the specified character from graphemes to phonemes.
-- **Levenshtein Distance**: The average Levenshtein distance between the predicted phonemes and the ground truth phonemes.
 - **Phoneme Error Rate (PER)**: The percentage of phonemes that are incorrectly predicted.
 
 ## Usage

--- a/data.py
+++ b/data.py
@@ -2,20 +2,23 @@ import re
 from functools import reduce
 from models import G2PModel
 
+# The choice of symbols is arbitrary and does not affect the calculation and the final result.
+# As long as each symbol represents a unique phoneme in its position,
+# it is fine even if the same symbol represents different phonemes in different positions.
 JYUTPING_TO_PHONEME_RULES = {
     r"ng": "N",
-    r"g(w|(?=u(?!N|k)))": "G",
-    r"k(w|(?=u(?!N|k)))": "K",
+    r"g(w|(?=u(?!N|k)))": "G",  # replace onsets of syllables beginning with gw- or gu-, excluding gung and guk
+    r"k(w|(?=u(?!N|k)))": "K",  # replace onsets of syllables beginning with kw- or ku-, excluding kung and kuk
     r"aa": "A",
     r"oe": "O",
     r"eo": "E",
     r"yu": "Y",
-    r"e(?=i)|i(?=N|k)": "I",
-    r"o(?=u)|u(?=N|k)": "U",
-    r"^(?=[mN]\d)": "__",
-    r"(?<=^h)(?=[mN]\d)": "h_",
-    r"^(?=[aeiouAEIOUY])": "_",
-    r"(?<=^.[aeiouAEIOUY])(?![iumnNptk])": "_",
+    r"e(?=i)|i(?=N|k)": "I",    # replace nuclei of syllables ending with -ei, -ing or -ik
+    r"o(?=u)|u(?=N|k)": "U",    # replace nuclei of syllables ending with -ou, -ung or -uk
+    r"^(?=[mN]\d)": "__",       # add null onsets and nuclei to syllabic m and ng
+    r"(?<=^h)(?=[mN]\d)": "_",  # add null nuclei to syllabic hm and hng
+    r"^(?=[aeiouAEIOUY])": "_", # add null onsets
+    r"(?<=^.[aeiouAEIOUY])(?![iumnNptk])": "_",  # add null codas
 }
 
 PHONEMES_PER_SYLLABLE = 4

--- a/data.py
+++ b/data.py
@@ -64,8 +64,6 @@ def calculate_accuracy(
 ):
     """
     Calculates the accuracy and Phoneme Error Rate (PER) for monosyllabic predictions.
-    The Levenshtein distance is always equivalent to the Phoneme Error Rate (PER)
-    since the number of phonemes of a Cantonese syllable must be 4.
 
     Args:
       predictions: A list of predicted phonemes.
@@ -77,7 +75,7 @@ def calculate_accuracy(
     """
     total_predictions = 0
     correct_predictions = 0
-    leven_distance = 0
+    total_errors = 0
 
     for text, query_id, true_phonemes, pred_jyutpings in zip(
         test_texts, test_query_ids, ground_truths, predictions
@@ -86,17 +84,17 @@ def calculate_accuracy(
             total_predictions += 1
             predicted_jyutping = pred_jyutpings[query_id]
             if predicted_jyutping is None:
-                leven_distance += 1
+                total_errors += PHONEMES_PER_SYLLABLE
             else:
                 predicted_phonemes = jyutping_to_phonemes(predicted_jyutping)
                 if predicted_phonemes == true_phonemes:
                     correct_predictions += 1
                 for i in range(PHONEMES_PER_SYLLABLE):
                     if predicted_phonemes[i] != true_phonemes[i]:
-                        leven_distance += 1 / PHONEMES_PER_SYLLABLE
+                        total_errors += 1
 
     acc = correct_predictions / total_predictions
-    per = leven_distance / total_predictions
+    per = total_errors / total_predictions / PHONEMES_PER_SYLLABLE
 
     return acc, per
 

--- a/data.py
+++ b/data.py
@@ -1,7 +1,34 @@
-from Levenshtein import ratio, distance
+import re
+from functools import reduce
 from models import G2PModel
 
+JYUTPING_TO_PHONEME_RULES = {
+    r"ng": "N",
+    r"g(w|(?=u(?!N|k)))": "G",
+    r"k(w|(?=u(?!N|k)))": "K",
+    r"aa": "A",
+    r"oe": "O",
+    r"eo": "E",
+    r"yu": "Y",
+    r"e(?=i)|i(?=N|k)": "I",
+    r"o(?=u)|u(?=N|k)": "U",
+    r"^(?=[mN]\d)": "__",
+    r"(?<=^h)(?=[mN]\d)": "h_",
+    r"^(?=[aeiouAEIOUY])": "_",
+    r"(?<=^.[aeiouAEIOUY])(?![iumnNptk])": "_",
+}
+
+PHONEMES_PER_SYLLABLE = 4
+
 ANCHOR_CHAR = "▁"
+
+
+def jyutping_to_phonemes(jyutping):
+    phonemes = reduce(lambda pron, rule: re.sub(*rule, pron), JYUTPING_TO_PHONEME_RULES.items(), jyutping)
+    if len(phonemes) != PHONEMES_PER_SYLLABLE:
+        # phonemes must be in the format (onset, nucleus, coda, tone)
+        raise ValueError(f"Invalid jyutping: {jyutping}, {phonemes}")
+    return phonemes
 
 
 def prepare_data(sent_path, lb_path=None, pos_path=None, max_samples=None):
@@ -14,7 +41,7 @@ def prepare_data(sent_path, lb_path=None, pos_path=None, max_samples=None):
 
         return texts, query_ids, None, None
     else:
-        phonemes = open(lb_path, encoding="utf-8").read().rstrip().split("\n")
+        jyutpings = open(lb_path, encoding="utf-8").read().rstrip().split("\n")
         pos_tags = (
             open(pos_path, encoding="utf-8").read().rstrip().split("\n")
             if pos_path
@@ -24,8 +51,10 @@ def prepare_data(sent_path, lb_path=None, pos_path=None, max_samples=None):
         if max_samples:
             texts = texts[:max_samples]
             query_ids = query_ids[:max_samples]
-            phonemes = phonemes[:max_samples]
+            jyutpings = jyutpings[:max_samples]
             pos_tags = pos_tags[:max_samples] if pos_tags else None
+
+        phonemes = [jyutping_to_phonemes(jyutping) for jyutping in jyutpings]
 
         return texts, query_ids, phonemes, pos_tags
 
@@ -33,7 +62,10 @@ def prepare_data(sent_path, lb_path=None, pos_path=None, max_samples=None):
 def calculate_accuracy(
     predictions, test_texts, test_query_ids, ground_truths, pos_tags=None
 ):
-    """Calculates accuracy and Levenshtein distance for single-phoneme predictions.
+    """
+    Calculates the accuracy and Phoneme Error Rate (PER) for monosyllabic predictions.
+    The Levenshtein distance is always equivalent to the Phoneme Error Rate (PER)
+    since the number of phonemes of a Cantonese syllable must be 4.
 
     Args:
       predictions: A list of predicted phonemes.
@@ -41,52 +73,32 @@ def calculate_accuracy(
       pos_tags: A list of part-of-speech tags.
 
     Returns:
-      (Accuracy score, Levenshtein distance)
+      (Accuracy score, PER score)
     """
-    total_predictions = len(predictions)
+    total_predictions = 0
     correct_predictions = 0
     leven_distance = 0
 
-    for text, query_id, true_phoneme, pred_phonemes in zip(
+    for text, query_id, true_phonemes, pred_jyutpings in zip(
         test_texts, test_query_ids, ground_truths, predictions
     ):
-        if len(pred_phonemes) > query_id:
-            predicted_phoneme = pred_phonemes[query_id]
-            leven_distance += 1 - ratio(true_phoneme, predicted_phoneme) if predicted_phoneme else 1
-            if pred_phonemes[query_id] == true_phoneme:
-                correct_predictions += 1
+        if len(pred_jyutpings) > query_id:
+            total_predictions += 1
+            predicted_jyutping = pred_jyutpings[query_id]
+            if predicted_jyutping is None:
+                leven_distance += 1
+            else:
+                predicted_phonemes = jyutping_to_phonemes(predicted_jyutping)
+                if predicted_phonemes == true_phonemes:
+                    correct_predictions += 1
+                for i in range(PHONEMES_PER_SYLLABLE):
+                    if predicted_phonemes[i] != true_phonemes[i]:
+                        leven_distance += 1 / PHONEMES_PER_SYLLABLE
 
-    accuracy = correct_predictions / total_predictions
-    leven_distance = leven_distance / total_predictions
+    acc = correct_predictions / total_predictions
+    per = leven_distance / total_predictions
 
-    return accuracy, leven_distance
-
-
-def calculate_per(
-    predictions, test_texts, test_query_ids, ground_truths, pos_tags=None
-):
-    """Calculates Phoneme Error Rate (PER) for single-phoneme predictions.
-
-    Args:
-      predictions: A list of predicted phonemes.
-      ground_truths: A list of ground truth phonemes.
-      pos_tags: A list of part-of-speech tags.
-
-    Returns:
-      PER score
-    """
-    total_phonemes = 0
-    total_errors = 0
-
-    for text, query_id, true_phoneme, pred_phonemes in zip(
-        test_texts, test_query_ids, ground_truths, predictions
-    ):
-        if len(pred_phonemes) > query_id:
-            predicted_phoneme = pred_phonemes[query_id]
-            total_phonemes += len(true_phoneme)
-            total_errors += distance(true_phoneme, predicted_phoneme) if predicted_phoneme else len(true_phoneme)
-
-    return total_errors / total_phonemes if total_phonemes > 0 else 0
+    return acc, per
 
 
 def test(
@@ -97,14 +109,9 @@ def test(
     )
     predictions = model(test_texts)
 
-    acc, distance = calculate_accuracy(
+    acc, per = calculate_accuracy(
         predictions, test_texts, test_query_ids, test_phonemes, test_pos
     )
 
-    per = calculate_per(
-        predictions, test_texts, test_query_ids, test_phonemes, test_pos
-    )
-
-    print(f"Accuracy: {acc:.2f}")
-    print(f"Levenshtein Distance: {distance:.2f}")
-    print(f"Phoneme Error Rate (PER): {per:.2f}")
+    print(f"Accuracy: {acc:.4f}")
+    print(f"Phoneme Error Rate (PER): {per:.4f}")

--- a/data/wordshk.lb
+++ b/data/wordshk.lb
@@ -1030,7 +1030,7 @@ pe1
 zoek2
 zaau6
 syu2
-kuaa1
+kwaa1
 tou4
 zung3
 zau3
@@ -1061,7 +1061,7 @@ lyun1
 mok1
 ou3
 ang2
-jay4
+jai4
 maan6
 dung2
 zoeng2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ToJyutping
 pycantonese
-levenshtein
 huggingface_hub
 modelscope

--- a/run.py
+++ b/run.py
@@ -6,7 +6,7 @@ from models import (
     # FunAudioModel,
 )
 import time
-from data import prepare_data, calculate_accuracy, calculate_per
+from data import prepare_data, calculate_accuracy
 import matplotlib.pyplot as plt
 import argparse
 
@@ -52,22 +52,17 @@ if __name__ == "__main__":
         predictions = model(test_texts)
         runtime = time.time() - start_time
 
-        acc, distance = calculate_accuracy(
-            predictions, test_texts, test_query_ids, test_phonemes, test_pos
-        )
-        per = calculate_per(
+        acc, per = calculate_accuracy(
             predictions, test_texts, test_query_ids, test_phonemes, test_pos
         )
 
         print(f"Accuracy: {acc:.4f}")
-        print(f"Levenshtein Distance: {distance:.4f}")
         print(f"Phoneme Error Rate (PER): {per:.4f}")
         print(f"Runtime: {runtime:.4f}s")
 
         model_names.append(model_name)
         results[model_name] = {
             "accuracy": acc,
-            "distance": distance,
             "per": per,
             "runtime": runtime,
         }


### PR DESCRIPTION
For correct calculation of PER, each Jyutping syllables are now transformed into 4 components, namely the onset, nucleus, coda and tone.

Levenshtein distance is not suitable as a metric of accuracy since the pronunciation of letters in different positions may be different. Plus, it depends on the romanisation system used.

The differences between the old and new results are insignificant, but two errors in the dataset were discovered.